### PR TITLE
Add DLT bindings and update devcontainer setup

### DIFF
--- a/.devcontainer/onCreateCommand.sh
+++ b/.devcontainer/onCreateCommand.sh
@@ -2,4 +2,9 @@
 set -eu
 
 sudo apt-get update
+
+# dlt-daemon and library
 sudo apt-get install -y dlt-daemon libdlt-dev
+
+# install bindgen requirements
+sudo apt-get install -y libclang-dev

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,4 +6,5 @@
         }
     ],
     "rust-analyzer.check.command": "clippy",
+    "rust-analyzer.cargo.buildScripts.enable": true
 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,7 @@ name = "dlt_log"
 version = "0.1.0"
 edition = "2021"
 
+[build-dependencies]
+bindgen = "0.71.1"
+
 [dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,19 @@
+use std::env;
+use std::path::PathBuf;
+
+// see https://rust-lang.github.io/rust-bindgen/tutorial-3.html
+fn main() {
+    println!("cargo:rustc-link-lib=dlt");
+
+    let bindings = bindgen::Builder::default()
+        .header("wrapper.h")
+        .allowlist_item("DltContext")
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
+        .generate()
+        .expect("Unable to generate bindings");
+
+    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
+    bindings
+        .write_to_file(out_path.join("bindings.rs"))
+        .expect("Couldn't write bindings!");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,15 @@
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+#![allow(non_snake_case)]
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
+
+pub fn try_ffi() {
+    let ctx = DltContext {
+        contextID: ['a' as i8, 'b' as i8, 'c' as i8, 'd' as i8],
+        log_level_pos: 0,
+        log_level_ptr: std::ptr::null_mut(),
+        trace_status_ptr: std::ptr::null_mut(),
+        mcnt: 0,
+    };
+    println!("context: {:?}", ctx);
 }
 
 #[cfg(test)]
@@ -7,8 +17,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+    fn try_ffi_test() {
+        try_ffi();
     }
 }

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,0 +1,1 @@
+#include <dlt/dlt.h>


### PR DESCRIPTION
- Install dlt-daemon and libdlt-dev in devcontainer
- Enable build scripts in rust-analyzer settings
- Add bindgen as a build dependency in Cargo.toml
- Create build.rs for generating DLT bindings
- Update lib.rs to include generated bindings and test function
- Add wrapper.h for DLT header inclusion