### PR TITLE
Add dependency installation step in release-plz workflow

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -22,6 +22,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Install dependencies
+        run: sudo apt-get install -y libdlt-dev
       - name: Run release-plz
         uses: release-plz/action@ca8762285a5dc0c220cb4a7896c9986ff6c97ecf # v0.5.88
         with:


### PR DESCRIPTION
This change adds a step to install the libdlt-dev dependency before running the release-plz action in the CI workflow.