### PR TITLE
chore: update metadata and fix image link in README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,13 @@
 name = "dlt_log"
 version = "0.1.1"
 description = "Log crate adapter for integrating with the Diagnostic Log and Trace (DLT) system"
+license = "MIT"
 license-file = "LICENSE"
 edition = "2021"
 repository = "https://github.com/rusty-projects/dlt_log-rs"
 keywords = ["dlt", "log", "logging", "adapter"]
 categories = ["development-tools::debugging"]
+exclude = ["doc/*.png"]
 
 [build-dependencies]
 bindgen = "0.71.1"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The DLT system is a flexible and scalable logging framework that is widely used in the automotive industry for logging and tracing in embedded systems. It provides features such as log level filtering, message formatting, and log message buffering. For more information about DLT, see the [DLT project on GitHub](https://github.com/COVESA/dlt-daemon).
 
-![Example logs in DLT viewer](https://github.com/rusty-projects/dlt_log-rs/blob/main/doc/dlt-viewer-example.png)
+![Example logs in DLT viewer](https://raw.githubusercontent.com/rusty-projects/dlt_log-rs/main/doc/dlt-viewer-example.png)
 
 ## Usage
 


### PR DESCRIPTION
- Add license information to Cargo.toml
- Exclude documentation images from package
- Update image link in README to use raw GitHub URL