### PR TITLE
Remove license-file entry from Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,6 @@ name = "dlt_log"
 version = "0.1.1"
 description = "Log crate adapter for integrating with the Diagnostic Log and Trace (DLT) system"
 license = "MIT"
-license-file = "LICENSE"
 edition = "2021"
 repository = "https://github.com/rusty-projects/dlt_log-rs"
 keywords = ["dlt", "log", "logging", "adapter"]


### PR DESCRIPTION
The license-file entry is no longer necessary as the license is already specified in the Cargo.toml file.