### PR TITLE
update DLT bindings and improve error handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["development-tools::debugging"]
 exclude = ["doc/*.png"]
 
 [build-dependencies]
-bindgen = "0.71.1"
+bindgen = "0.71"
 
 [dependencies]
 log = { version = "0.4", features = ["std"] }

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The library defines an `InitializeError` enum to represent possible errors that 
 
 ## Integration
 
-The integration with the DLT system is achieved through the `libdlt` module, which provides FFI (Foreign Function Interface) bindings to the underlying C library for DLT. The `bindgen` tool is used to generate these bindings. The bindings are generated during the build process in order to ensure that the Rust code remains in sync with the system's DLT library.
+The integration with the DLT system is achieved through the underlying C library for DLT. The `bindgen` tool is used to generate the FFI (Foreign Function Interface) bindings. The bindings are generated during the build process in order to ensure that the Rust code remains in sync with the system's DLT library.
 
 ## License
 

--- a/build.rs
+++ b/build.rs
@@ -12,12 +12,13 @@ fn main() {
         .allowlist_item("dlt_register_app")
         .allowlist_item("dlt_register_context")
         .allowlist_item("dlt_log_string")
+        // create rust-friendly enums
+        .rustified_enum("DltReturnValue")
+        .rustified_enum("DltLogLevelType")
         // the return value shall always be checked
         .must_use_type("DltReturnValue")
         // default for initialization of DltContext
         .derive_default(true)
-        // avoid unncessary prepending, there are no conflicts
-        .prepend_enum_name(false)
         .generate()
         .expect("Unable to generate bindings");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,10 @@ use log::{Level, Metadata, Record, SetLoggerError};
 use std::ffi::{CString, NulError};
 
 /// this module includes the generated bindings for the DLT library
-pub mod libdlt;
+mod libdlt;
+
+// re-export the DLT return value from the `libdlt` module for use in the `InitializeError` enum
+pub use libdlt::DltReturnValue;
 
 #[derive(Debug)]
 /// Represents possible errors that can occur during initialization.
@@ -25,7 +28,7 @@ pub enum InitializeError {
     /// This variant encapsulates the `DltReturnValue` from the `libdlt` crate,
     /// which provides detailed information about the specific error encountered
     /// during DLT operations.
-    DltLibraryError(libdlt::DltReturnValue),
+    DltLibraryError(DltReturnValue),
 }
 
 impl From<NulError> for InitializeError {
@@ -80,7 +83,7 @@ pub fn init(
     let c_app_description = CString::new(app_description)?;
     let dlt_return_value =
         unsafe { libdlt::dlt_register_app(c_app_id.as_ptr(), c_app_description.as_ptr()) };
-    if dlt_return_value != libdlt::DLT_RETURN_OK {
+    if dlt_return_value != DltReturnValue::DLT_RETURN_OK {
         return Err(InitializeError::DltLibraryError(dlt_return_value));
     }
 
@@ -100,7 +103,7 @@ pub fn init(
             c_context_description.as_ptr(),
         )
     };
-    if dlt_return_value != libdlt::DLT_RETURN_OK {
+    if dlt_return_value != DltReturnValue::DLT_RETURN_OK {
         return Err(InitializeError::DltLibraryError(dlt_return_value));
     }
 
@@ -130,11 +133,11 @@ impl log::Log for DltLogger {
 
     fn log(&self, record: &Record) {
         let level = match record.level() {
-            Level::Error => libdlt::DLT_LOG_ERROR,
-            Level::Warn => libdlt::DLT_LOG_WARN,
-            Level::Info => libdlt::DLT_LOG_INFO,
-            Level::Debug => libdlt::DLT_LOG_DEBUG,
-            Level::Trace => libdlt::DLT_LOG_VERBOSE,
+            Level::Error => libdlt::DltLogLevelType::DLT_LOG_ERROR,
+            Level::Warn => libdlt::DltLogLevelType::DLT_LOG_WARN,
+            Level::Info => libdlt::DltLogLevelType::DLT_LOG_INFO,
+            Level::Debug => libdlt::DltLogLevelType::DLT_LOG_DEBUG,
+            Level::Trace => libdlt::DltLogLevelType::DLT_LOG_VERBOSE,
         };
 
         let text = format!("{}", record.args());

--- a/src/libdlt.rs
+++ b/src/libdlt.rs
@@ -1,4 +1,4 @@
 #![allow(non_snake_case)]
-#![allow(unused_attributes)]
+#![allow(non_camel_case_types)]
 #![allow(dead_code)]
 include!(concat!(env!("OUT_DIR"), "/libdlt_bindings.rs"));


### PR DESCRIPTION
- Re-export DltReturnValue for easier access in InitializeError
- Update logging levels to use DltLogLevelType enums
- Adjust attributes in libdlt.rs for better clarity