### PR TITLE
Add devcontainer lock file and update CI config

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/rust:1.5.0": {
+      "version": "1.5.0",
+      "resolved": "ghcr.io/devcontainers/features/rust@sha256:0c55e65f2e3df736e478f26ee4d5ed41bae6b54dac1318c443e31444c8ed283c",
+      "integrity": "sha256:0c55e65f2e3df736e478f26ee4d5ed41bae6b54dac1318c443e31444c8ed283c"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "image": "mcr.microsoft.com/devcontainers/base:noble",
   "features": {
     "ghcr.io/devcontainers/features/rust:1.5.0": {
-      "version": "nightly-2026-03-14",
+      "version": "nightly-2026-06-10",
       "profile": "default",
       "targets": ""
     }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,15 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 6 * * *'
 
 jobs:
 
   build:
     strategy:
       matrix:
-        rust_version: ["latest", "1.94", "1.93", "1.92", "1.91", "1.90", "1.89", "1.88", "1.87", "1.86", "1.85", "1.84", "1.83", "1.82", "beta", "nightly"]
+        rust_version: ["1.82", "latest", "beta", "nightly"] # 1.82: oldest supported version
       fail-fast: false
 
     runs-on: ubuntu-24.04

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: '0 6 * * *'
 
 jobs:
 


### PR DESCRIPTION
- Introduced a new devcontainer lock file for Rust feature versioning.
- Updated Rust version in devcontainer.json to nightly-2026-06-10.
- Adjusted CI workflow to include scheduled runs and refined Rust versions.